### PR TITLE
Implement Identifier Results page logic

### DIFF
--- a/client/quasar.conf.js
+++ b/client/quasar.conf.js
@@ -44,6 +44,7 @@ module.exports = function (ctx) {
       components: [
         'QLayout',
         'QLayoutHeader',
+        'QLayoutFooter',
         'QLayoutDrawer',
         'QPageContainer',
         'QPage',
@@ -80,6 +81,7 @@ module.exports = function (ctx) {
         'QInput',
         'QFab',
         'QFabAction',
+        'QItemSeparator',
       ],
       directives: [
         'Ripple'

--- a/client/quasar.conf.js
+++ b/client/quasar.conf.js
@@ -86,7 +86,8 @@ module.exports = function (ctx) {
       ],
       // Quasar plugins
       plugins: [
-        'Notify'
+        'Notify',
+        'Loading',
       ]//,
       // config: {
       //   cordova: {

--- a/client/src-cordova/config.xml
+++ b/client/src-cordova/config.xml
@@ -6,6 +6,7 @@
         Apache Cordova Team
     </author>
     <content src="index.html" />
+    <preference name="DisallowOverscroll" value="true" />
     <plugin name="cordova-plugin-whitelist" spec="1" />
     <access origin="*" />
     <allow-intent href="http://*/*" />

--- a/client/src/components/Home/PlantDirectory.vue
+++ b/client/src/components/Home/PlantDirectory.vue
@@ -11,7 +11,7 @@
       :visible-columns="visibleColumns"
       row-key="name"
     >
-      <template slot="top-right" slot-scope="props">
+      <template slot="top" slot-scope="props">
         <q-search hide-underline clearable v-model="filter" />
       </template>
 

--- a/client/src/components/Home/PlantDirectory.vue
+++ b/client/src/components/Home/PlantDirectory.vue
@@ -1,51 +1,48 @@
 <template>
-  <q-card>
-    <q-card-main>
+  <q-card-main>
+    <q-table
+      grid
+      hide-header
+      :data="tableData"
+      :columns="columns"
+      :filter="filter"
+      :selection="selection"
+      :selected.sync="selected"
+      :visible-columns="visibleColumns"
+      row-key="name"
+    >
+      <template slot="top-right" slot-scope="props">
+        <q-search hide-underline clearable v-model="filter" />
+      </template>
 
-      <q-table
-        grid
-        hide-header
-        :data="tableData"
-        :columns="columns"
-        :filter="filter"
-        :selection="selection"
-        :selected.sync="selected"
-        :visible-columns="visibleColumns"
-        row-key="name"
+      <div
+        slot="item"
+        slot-scope="props"
+        class="q-pa-xs col-xs-12 col-sm-6 col-md-4 transition-generic"
+        :style="props.selected ? 'transform: scale(0.95);' : ''"
       >
-        <template slot="top-right" slot-scope="props">
-          <q-search hide-underline clearable v-model="filter" />
-        </template>
-
-        <div
-          slot="item"
-          slot-scope="props"
-          class="q-pa-xs col-xs-12 col-sm-6 col-md-4 transition-generic"
-          :style="props.selected ? 'transform: scale(0.95);' : ''"
+        <q-card
+          class="transition-generic cursor-pointer"
+          :class="props.selected ? 'bg-grey-2' : ''"
+          @click.native="props.selected = !props.selected"
         >
-          <q-card
-            class="transition-generic cursor-pointer"
-            :class="props.selected ? 'bg-grey-2' : ''"
-            @click.native="props.selected = !props.selected"
-          >
-            <q-card-title class="relative-position">
-              {{ props.row.name }}
-            </q-card-title>
+          <q-card-title class="relative-position">
+            {{ props.row.name }}
+          </q-card-title>
 
-            <q-card-separator />
+          <q-card-separator />
 
-            <q-card-media>
-              <img :src="props.row.image" />
-            </q-card-media>
+          <q-card-media>
+            <img :src="props.row.image" />
+          </q-card-media>
 
-            <q-card-actions align=center>
-              <q-btn flat>Information <q-icon name="keyboard_arrow_right" /></q-btn>
-            </q-card-actions>
-          </q-card>
-        </div>
-      </q-table>
-    </q-card-main>
-  </q-card>
+          <q-card-actions align=center>
+            <q-btn flat>Information <q-icon name="keyboard_arrow_right" /></q-btn>
+          </q-card-actions>
+        </q-card>
+      </div>
+    </q-table>
+  </q-card-main>
 </template>
 
 <script>

--- a/client/src/components/Home/Stepper.vue
+++ b/client/src/components/Home/Stepper.vue
@@ -87,7 +87,6 @@ export default {
 };
 </script>
 
-
 <style>
 .actions {
   margin: 16px;

--- a/client/src/components/Home/Stepper.vue
+++ b/client/src/components/Home/Stepper.vue
@@ -73,7 +73,9 @@
       <q-card-separator />
 
       <q-card-actions>
-        <q-btn flat>Detect Plant</q-btn>
+        <div class="actions">
+          <q-btn color="primary" to="/detector">I'm ready to detect plants</q-btn>
+        </div>
       </q-card-actions>
     </q-card>
   </div>
@@ -81,11 +83,13 @@
 
 <script>
 export default {
-
+  name: 'Stepper',
 };
 </script>
 
 
 <style>
-
+.actions {
+  margin: 16px;
+}
 </style>

--- a/client/src/components/Home/Stepper.vue
+++ b/client/src/components/Home/Stepper.vue
@@ -74,7 +74,10 @@
 
       <q-card-actions>
         <div class="actions">
-          <q-btn color="primary" to="/detector">I'm ready to detect plants</q-btn>
+          <PlantDetection
+            v-bind:button="{ color: 'primary' }"
+            text="I'm ready to detect plants"
+          />
         </div>
       </q-card-actions>
     </q-card>
@@ -82,8 +85,13 @@
 </template>
 
 <script>
+import PlantDetection from '../../pages/PlantDetection';
+
 export default {
   name: 'Stepper',
+  components: {
+    PlantDetection,
+  },
 };
 </script>
 

--- a/client/src/components/Home/Stepper.vue
+++ b/client/src/components/Home/Stepper.vue
@@ -74,7 +74,7 @@
 
       <q-card-actions>
         <div class="actions">
-          <PlantDetection
+          <CameraButton
             v-bind:button="{ color: 'primary' }"
             text="I'm ready to detect plants"
           />
@@ -85,12 +85,12 @@
 </template>
 
 <script>
-import PlantDetection from '../../pages/PlantDetection';
+import CameraButton from '../PlantIdentification/CameraButton';
 
 export default {
   name: 'Stepper',
   components: {
-    PlantDetection,
+    CameraButton,
   },
 };
 </script>

--- a/client/src/components/PlantIdentification/CameraButton.vue
+++ b/client/src/components/PlantIdentification/CameraButton.vue
@@ -4,7 +4,7 @@
 
 <script>
 export default {
-  name: 'PlantDetection',
+  name: 'CameraButton',
   props: {
     text: {
       type: String,
@@ -71,7 +71,7 @@ export default {
           function uploadImage() {
             const blob = convertImageToBlob(this.result);
             const formData = constructFormData(blob);
-            const appHost = 'http://localhost:3000';
+            const appHost = 'https://78d4349c.ngrok.io';
             const imageUploadUrl = `${appHost}/images/upload`;
             view.$axios.post(imageUploadUrl, formData)
               .then((res) => {

--- a/client/src/layouts/Layout.vue
+++ b/client/src/layouts/Layout.vue
@@ -9,7 +9,7 @@
         <q-toolbar-title>
           <router-link to="/" style="text-decoration: none; color: white;">ohia.ai</router-link>
           <div slot="subtitle">
-            Helping to identify native and invasive plants in Hawaii.
+            Help identify native and invasive plants in Hawaii.
           </div>
         </q-toolbar-title>
       </q-toolbar>
@@ -25,7 +25,7 @@
           <q-btn flat round dense style="margin-right: 28px;" 
             size="lg" icon="home" to="/" />
           <q-btn flat round dense style="margin-right: 28px;" 
-            size="lg" icon="info" to="/about" />
+            size="lg" icon="info" to="/help" />
           <q-btn flat round dense style="margin-right: 28px;" 
             size="lg" icon="camera_alt" to="/detector" />
           <q-btn flat round dense style="margin-right: 28px;" 

--- a/client/src/layouts/Layout.vue
+++ b/client/src/layouts/Layout.vue
@@ -26,8 +26,16 @@
             size="lg" icon="spa" to="/" />
           <q-btn flat round dense class="button" 
             size="lg" icon="help" to="/help" />
-          <q-btn flat round dense class="button" 
-            size="lg" icon="camera_alt" to="/detector" />
+          <PlantDetection
+            v-bind:button="{
+              flat: true,
+              round: true,
+              dense: true,
+              class: 'button',
+              size: 'lg',
+              icon: 'camera_alt',
+            }"
+          />
           <q-btn flat round dense class="button" 
             size="lg" icon="image_search" to="/identify" />
         </div>
@@ -37,8 +45,13 @@
 </template>
 
 <script>
+import PlantDetection from '../pages/PlantDetection';
+
 export default {
   name: 'Layout',
+  components: {
+    PlantDetection,
+  },
 };
 </script>
 

--- a/client/src/layouts/Layout.vue
+++ b/client/src/layouts/Layout.vue
@@ -26,7 +26,7 @@
             size="lg" icon="spa" to="/" />
           <q-btn flat round dense class="button" 
             size="lg" icon="help" to="/help" />
-          <PlantDetection
+          <CameraButton
             v-bind:button="{
               flat: true,
               round: true,
@@ -45,12 +45,12 @@
 </template>
 
 <script>
-import PlantDetection from '../pages/PlantDetection';
+import CameraButton from '../components/PlantIdentification/CameraButton';
 
 export default {
   name: 'Layout',
   components: {
-    PlantDetection,
+    CameraButton,
   },
 };
 </script>

--- a/client/src/layouts/Layout.vue
+++ b/client/src/layouts/Layout.vue
@@ -7,7 +7,7 @@
         :inverted="$q.theme === 'ios'"
       >
         <q-toolbar-title>
-          <router-link to="/" style="text-decoration: none; color: white;">ohia.ai</router-link>
+          <router-link to="/" class="title">ohia.ai</router-link>
           <div slot="subtitle">
             Help identify native and invasive plants in Hawaii.
           </div>
@@ -21,7 +21,7 @@
 
     <q-layout-footer>
       <q-toolbar color="secondary" inverted>
-        <div style="display: flex; justify-content: space-around;">
+        <div class="nav-bar">
           <q-btn flat round dense class="button" 
             size="lg" icon="spa" to="/" />
           <q-btn flat round dense class="button" 
@@ -43,7 +43,15 @@ export default {
 </script>
 
 <style>
+.title {
+  text-decoration: none;
+  color: white;
+}
 .button {
   margin-right: 54px;
+}
+.nav-bar {
+  display: flex;
+  justify-content: space-around;
 }
 </style>

--- a/client/src/layouts/Layout.vue
+++ b/client/src/layouts/Layout.vue
@@ -40,7 +40,7 @@
 
 <script>
 export default {
-  name: 'MyLayout',
+  name: 'Layout',
 };
 </script>
 

--- a/client/src/layouts/Layout.vue
+++ b/client/src/layouts/Layout.vue
@@ -9,7 +9,7 @@
         <q-toolbar-title>
           <router-link to="/" class="title">ohia.ai</router-link>
           <div slot="subtitle">
-            Help identify native and invasive plants in Hawaii.
+            Helping to identify native and invasive plants in Hawaii
           </div>
         </q-toolbar-title>
       </q-toolbar>

--- a/client/src/layouts/Layout.vue
+++ b/client/src/layouts/Layout.vue
@@ -22,15 +22,13 @@
     <q-layout-footer>
       <q-toolbar color="secondary" inverted>
         <div style="display: flex; justify-content: space-around;">
-          <q-btn flat round dense style="margin-right: 28px;" 
-            size="lg" icon="home" to="/" />
-          <q-btn flat round dense style="margin-right: 28px;" 
-            size="lg" icon="info" to="/help" />
-          <q-btn flat round dense style="margin-right: 28px;" 
+          <q-btn flat round dense class="button" 
+            size="lg" icon="spa" to="/" />
+          <q-btn flat round dense class="button" 
+            size="lg" icon="help" to="/help" />
+          <q-btn flat round dense class="button" 
             size="lg" icon="camera_alt" to="/detector" />
-          <q-btn flat round dense style="margin-right: 28px;" 
-            size="lg" icon="spa" to="/plant" />
-          <q-btn flat round dense style="margin-right: 28px;" 
+          <q-btn flat round dense class="button" 
             size="lg" icon="image_search" to="/identify" />
         </div>
       </q-toolbar>
@@ -45,4 +43,7 @@ export default {
 </script>
 
 <style>
+.button {
+  margin-right: 54px;
+}
 </style>

--- a/client/src/layouts/MyLayout.vue
+++ b/client/src/layouts/MyLayout.vue
@@ -18,22 +18,29 @@
     <q-page-container>
       <router-view />
     </q-page-container>
+
+    <q-layout-footer>
+      <q-toolbar color="secondary" inverted>
+        <div style="display: flex; justify-content: space-around;">
+          <q-btn flat round dense style="margin-right: 28px;" 
+            size="lg" icon="home" to="/" />
+          <q-btn flat round dense style="margin-right: 28px;" 
+            size="lg" icon="info" to="/about" />
+          <q-btn flat round dense style="margin-right: 28px;" 
+            size="lg" icon="camera_alt" to="/detector" />
+          <q-btn flat round dense style="margin-right: 28px;" 
+            size="lg" icon="spa" to="/plant" />
+          <q-btn flat round dense style="margin-right: 28px;" 
+            size="lg" icon="image_search" to="/identify" />
+        </div>
+      </q-toolbar>
+    </q-layout-footer>
   </q-layout>
 </template>
 
 <script>
-import { openURL } from 'quasar';
-
 export default {
   name: 'MyLayout',
-  data() {
-    return {
-      leftDrawerOpen: this.$q.platform.is.desktop,
-    };
-  },
-  methods: {
-    openURL,
-  },
 };
 </script>
 

--- a/client/src/layouts/MyLayout.vue
+++ b/client/src/layouts/MyLayout.vue
@@ -6,57 +6,14 @@
         :glossy="$q.theme === 'ios'"
         :inverted="$q.theme === 'ios'"
       >
-        <q-btn
-          flat
-          dense
-          round
-          @click="leftDrawerOpen = !leftDrawerOpen"
-          aria-label="Menu"
-        >
-          <q-icon name="menu" />
-        </q-btn>
-
         <q-toolbar-title>
-          ohia.ai
+          <router-link to="/" style="text-decoration: none; color: white;">ohia.ai</router-link>
           <div slot="subtitle">
-            An open Hawaiian indigenous plant identification and aggregation application.
+            Helping to identify native and invasive plants in Hawaii.
           </div>
         </q-toolbar-title>
       </q-toolbar>
     </q-layout-header>
-
-    <q-layout-drawer
-      v-model="leftDrawerOpen"
-      :content-class="$q.theme === 'mat' ? 'bg-grey-2' : null"
-    >
-      <q-list
-        no-border
-        link
-        inset-delimiter
-      >
-        <q-list-header>Essential Links</q-list-header>
-        <q-item @click.native="openURL('http://quasar-framework.org')">
-          <q-item-side icon="school" />
-          <q-item-main label="Docs" sublabel="quasar-framework.org" />
-        </q-item>
-        <q-item @click.native="openURL('https://github.com/quasarframework/')">
-          <q-item-side icon="code" />
-          <q-item-main label="GitHub" sublabel="github.com/quasarframework" />
-        </q-item>
-        <q-item @click.native="openURL('https://discord.gg/5TDhbDg')">
-          <q-item-side icon="chat" />
-          <q-item-main label="Discord Chat Channel" sublabel="https://discord.gg/5TDhbDg" />
-        </q-item>
-        <q-item @click.native="openURL('http://forum.quasar-framework.org')">
-          <q-item-side icon="record_voice_over" />
-          <q-item-main label="Forum" sublabel="forum.quasar-framework.org" />
-        </q-item>
-        <q-item @click.native="openURL('https://twitter.com/quasarframework')">
-          <q-item-side icon="rss feed" />
-          <q-item-main label="Twitter" sublabel="@quasarframework" />
-        </q-item>
-      </q-list>
-    </q-layout-drawer>
 
     <q-page-container>
       <router-view />

--- a/client/src/pages/Help.vue
+++ b/client/src/pages/Help.vue
@@ -4,9 +4,6 @@
   </q-page>
 </template>
 
-<style>
-</style>
-
 <script>
 import Stepper from '../components/Home/Stepper';
 
@@ -17,3 +14,6 @@ export default {
   },
 };
 </script>
+
+<style>
+</style>

--- a/client/src/pages/Help.vue
+++ b/client/src/pages/Help.vue
@@ -1,0 +1,19 @@
+<template>
+  <q-page>
+    <Stepper />
+  </q-page>
+</template>
+
+<style>
+</style>
+
+<script>
+import Stepper from '../components/Home/Stepper';
+
+export default {
+  name: 'Help',
+  components: {
+    Stepper,
+  },
+};
+</script>

--- a/client/src/pages/Index.vue
+++ b/client/src/pages/Index.vue
@@ -1,33 +1,21 @@
 <template>
-  <q-page padding>
-    <div class="row gutter-sm">
-      <div class="col-sm-12 col-md-6">
-        <Stepper />
-      </div>
-      <div class="col-sm-12 col-md-6">
-        <plant-detection class="" />
-      </div>
-    </div>
-    <br />
+  <q-page>
+    <q-card-title>Browse the flora of Hawaii</q-card-title>
+    <q-card-separator />
     <plant-directory />
-    <br />
   </q-page>
 </template>
 
-<style>
-</style>
-
 <script>
-import PlantDetection from './PlantDetection';
-import Stepper from '../components/Home/Stepper';
 import PlantDirectory from '../components/Home/PlantDirectory';
 
 export default {
   name: 'PageIndex',
   components: {
-    PlantDetection,
-    Stepper,
     PlantDirectory,
   },
 };
 </script>
+
+<style>
+</style>

--- a/client/src/pages/PlantDetection.vue
+++ b/client/src/pages/PlantDetection.vue
@@ -60,6 +60,7 @@ export default {
         (filePath) => {
           // TODO: There's a noticeable delay before the spinner and overlay appears
           view.$q.loading.show({
+            delay: 0, // ms
             message: 'Uploading and identifying...',
           });
           const convertImageToBlob = (result) => {

--- a/client/src/pages/PlantDetection.vue
+++ b/client/src/pages/PlantDetection.vue
@@ -11,13 +11,6 @@
   </q-card>
 </template>
 
-<style>
-.image {
-  width: 100%;
-  height: auto;
-}
-</style>
-
 <script>
 export default {
   name: 'PlantDetection',
@@ -124,3 +117,10 @@ export default {
   },
 };
 </script>
+
+<style>
+.image {
+  width: 100%;
+  height: auto;
+}
+</style>

--- a/client/src/pages/PlantDetection.vue
+++ b/client/src/pages/PlantDetection.vue
@@ -5,8 +5,7 @@
     </q-card-title>
 
     <q-card-main>
-      <q-btn color="primary" label="Detect Plant" @click="captureImage" />
-
+      <q-btn color="primary" @click="captureImage">Detect Plant</q-btn>
       <img :src="imageSrc" class="image">
     </q-card-main>
   </q-card>
@@ -25,8 +24,8 @@ export default {
   data() {
     return {
       imageSrc: '',
-      latitude: 10,
-      longitude: 12,
+      latitude: 0,
+      longitude: 0,
     };
   },
   methods: {
@@ -48,6 +47,7 @@ export default {
         cameraDirection: camera.Direction.BACK, // Use the back-facing camera
       };
       const displayErrorMessage = () => {
+        view.$q.loading.hide();
         view.$q.notify({
           color: 'negative',
           position: 'top',
@@ -58,8 +58,10 @@ export default {
 
       camera.getPicture(
         (filePath) => {
-          const fullPath = filePath.replace('assets-library://', 'cdvfile://localhost/assets-library/');
-          view.imageSrc = fullPath;
+          // TODO: There's a noticeable delay before the spinner and overlay appears
+          view.$q.loading.show({
+            message: 'Uploading and identifying...',
+          });
           const convertImageToBlob = (result) => {
             // Create a blob based on the FileReader "result",
             // which we asked to be retrieved as an ArrayBuffer
@@ -81,6 +83,10 @@ export default {
             view.$axios.post(imageUploadUrl, formData)
               .then((res) => {
                 console.log('res.data', JSON.stringify(res.data.predictions));
+                view.$q.loading.hide();
+                const fullPath = filePath
+                  .replace('assets-library://', 'cdvfile://localhost/assets-library/');
+                view.imageSrc = fullPath;
               })
               .catch(() => {
                 displayErrorMessage();
@@ -103,6 +109,7 @@ export default {
         },
         (err) => {
           console.error('Error accessing the device camera:', err);
+          view.$q.loading.hide();
           view.$q.notify({
             color: 'negative',
             position: 'top',

--- a/client/src/pages/PlantDetection.vue
+++ b/client/src/pages/PlantDetection.vue
@@ -1,19 +1,18 @@
 <template>
-  <q-card>
-    <q-card-title>
-      Plant Detection
-    </q-card-title>
-
-    <q-card-main>
-      <q-btn color="primary" @click="captureImage">Detect Plant</q-btn>
-      <img :src="imageSrc" class="image">
-    </q-card-main>
-  </q-card>
+  <q-btn v-bind="button" @click="captureImage">{{ text }}</q-btn>
 </template>
 
 <script>
 export default {
   name: 'PlantDetection',
+  props: {
+    text: {
+      type: String,
+    },
+    button: {
+      type: Object,
+    },
+  },
   data() {
     return {
       imageSrc: '',
@@ -53,7 +52,7 @@ export default {
         (filePath) => {
           // TODO: There's a noticeable delay before the spinner and overlay appears
           view.$q.loading.show({
-            delay: 0, // ms
+            delay: 100, // ms
             message: 'Uploading and identifying...',
           });
           const convertImageToBlob = (result) => {
@@ -119,8 +118,4 @@ export default {
 </script>
 
 <style>
-.image {
-  width: 100%;
-  height: auto;
-}
 </style>

--- a/client/src/router/routes.js
+++ b/client/src/router/routes.js
@@ -1,4 +1,3 @@
-
 const routes = [
   {
     path: '/',

--- a/client/src/router/routes.js
+++ b/client/src/router/routes.js
@@ -20,16 +20,6 @@ const routes = [
     ],
   },
   {
-    path: '/detector',
-    component: () => import('layouts/Layout.vue'),
-    children: [
-      {
-        path: '',
-        component: () => import('pages/PlantDetection.vue'),
-      },
-    ],
-  },
-  {
     path: '/plant',
     component: () => import('layouts/Layout.vue'),
     children: [

--- a/client/src/router/routes.js
+++ b/client/src/router/routes.js
@@ -2,7 +2,7 @@
 const routes = [
   {
     path: '/',
-    component: () => import('layouts/MyLayout.vue'),
+    component: () => import('layouts/Layout.vue'),
     children: [
       {
         path: '',
@@ -12,7 +12,7 @@ const routes = [
   },
   {
     path: '/detector',
-    component: () => import('layouts/MyLayout.vue'),
+    component: () => import('layouts/Layout.vue'),
     children: [
       {
         path: '',
@@ -22,7 +22,7 @@ const routes = [
   },
   {
     path: '/plant',
-    component: () => import('layouts/MyLayout.vue'),
+    component: () => import('layouts/Layout.vue'),
     children: [
       {
         path: '',
@@ -32,7 +32,7 @@ const routes = [
   },
   {
     path: '/identify',
-    component: () => import('layouts/MyLayout.vue'),
+    component: () => import('layouts/Layout.vue'),
     children: [
       {
         path: '',

--- a/client/src/router/routes.js
+++ b/client/src/router/routes.js
@@ -11,6 +11,16 @@ const routes = [
     ],
   },
   {
+    path: '/help',
+    component: () => import('layouts/Layout.vue'),
+    children: [
+      {
+        path: '',
+        component: () => import('pages/Help.vue'),
+      },
+    ],
+  },
+  {
     path: '/detector',
     component: () => import('layouts/Layout.vue'),
     children: [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "dev-server": "nodemon server/index.js",
-    "db:migrate": "knex migrate:latest --knexfile server/knexfile.js"
+    "db:migrate": "knex migrate:latest --knexfile server/knexfile.js",
+    "db:rollback": "knex migrate:rollback --knexfile server/knexfile.js"
   },
   "author": "Team ohia.ai",
   "license": "MIT",


### PR DESCRIPTION
- Resolves #48.
- Also adds a bottom nav toolbar and modifies some pages/routes.
- Note: In the browser, the app appears to scroll past the top and bottom of the content, but that has been fixed on iOS. The toolbar completely hides the background on an iPhone (unlike how it may look on the browser).

Clicking on flower icon button:
![image](https://user-images.githubusercontent.com/1342429/47941729-72a86f00-de93-11e8-8224-06cbefefb0e1.png)

Clicking on help icon button:
![image](https://user-images.githubusercontent.com/1342429/47941755-88b62f80-de93-11e8-97ab-472b6a31b80f.png)

Clicking on "I'm ready to detect plants" button and camera icon buttons starts the camera, upload, and identification process.

Clicking on the last icon brings up Identifier Results (for now -- going to remove eventually; these results should only appear at the end of the camera/upload/identify process):
![image](https://user-images.githubusercontent.com/1342429/47941846-e21e5e80-de93-11e8-8bfa-3c1245ae5979.png)